### PR TITLE
add try catch to use SPM function to read residuals

### DIFF
--- a/plot_power_spectra_of_GLM_residuals.m
+++ b/plot_power_spectra_of_GLM_residuals.m
@@ -41,13 +41,22 @@ function plot_power_spectra_of_GLM_residuals(path_to_results, TR, cutoff_freq, a
 
    %-for SPM
    elseif exist('Res_0001.nii',       'file') == 2
+       
       SPM_res4d_name   = dir('Res_*.nii');
       SPM_res4d_all    = '';
-      for i            = 1:length(SPM_res4d_name)
-         SPM_res4d_all = [SPM_res4d_all ' ' SPM_res4d_name(i).name];
+      
+      try
+          for i            = 1:length(SPM_res4d_name)
+              SPM_res4d_all = [SPM_res4d_all ' ' SPM_res4d_name(i).name];
+          end
+          system(['fslmerge -t res4d ' SPM_res4d_all]);
+          res4d            = niftiread('res4d.nii.gz');
+      catch % in case we get a crash we rely on spm function
+          SPM_res4d_all = char({SPM_res4d_name.name}');
+          spm_file_merge(SPM_res4d_all, 'res4d.nii');
+          res4d = spm_read_vols(spm_vol('res4d.nii'));
       end
-      system(['fslmerge -t res4d ' SPM_res4d_all]);
-      res4d            = niftiread('res4d.nii.gz');
+      
    else
 
       disp('No GLM residuals found! If you run SPM, remember to put command VRes = spm_write_residuals(SPM, NaN) at the end of the SPM script. Otherwise, SPM by default deletes the GLM residuals.');


### PR DESCRIPTION
I talked about your article today in a journal club. Mostly used as a very good vehicle to talk about auto-correlation correction in fMRI. See [here](https://github.com/Remi-Gau/talk_sphericity_correction).

I added a couple of lines to your power spectrum plotting function: a try-catch to only rely on SPM functions. It might help other people to use if they don't have FSL or niftiread in their path.

Let me know what you think.